### PR TITLE
Bug - Version Specific Code

### DIFF
--- a/create_venv.sh
+++ b/create_venv.sh
@@ -7,7 +7,7 @@ function create_venv () {
   fi
 
   echo "Creating virtualenv"
-  pip install --user virtualenv==20.24.6
+  python3 -m pip install --user virtualenv==20.24.6
 
   NILLION_VENV=".venv"
   mkdir -p "$NILLION_VENV"
@@ -16,7 +16,7 @@ function create_venv () {
   python3 -m pip install -r requirements.txt
 
   echo "Virtualenv: $NILLION_VENV"
-  echo "Check the $NILLION_VENV/lib/python3/site-packages folder to make sure you have py_nillion_client and nada_dsl packages"
+  echo "Check the $NILLION_VENV/lib/python3.1X/site-packages folder to make sure you have py_nillion_client and nada_dsl packages"
   echo "📋 Copy and run the following command to activate your environment:"
   echo "source $NILLION_VENV/bin/activate"
 }

--- a/create_venv.sh
+++ b/create_venv.sh
@@ -11,12 +11,12 @@ function create_venv () {
 
   NILLION_VENV=".venv"
   mkdir -p "$NILLION_VENV"
-  python3.11 -m virtualenv -p python3.11 "$NILLION_VENV"
+  python3 -m virtualenv -p python3 "$NILLION_VENV"
   source "$NILLION_VENV/bin/activate"
-  python3.11 -m pip install -r requirements.txt
+  python3 -m pip install -r requirements.txt
 
   echo "Virtualenv: $NILLION_VENV"
-  echo "Check the $NILLION_VENV/lib/python3.11/site-packages folder to make sure you have py_nillion_client and nada_dsl packages"
+  echo "Check the $NILLION_VENV/lib/python3/site-packages folder to make sure you have py_nillion_client and nada_dsl packages"
   echo "📋 Copy and run the following command to activate your environment:"
   echo "source $NILLION_VENV/bin/activate"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 python-dotenv==1.0.0
-nada-dsl==0.0.7
-py-nillion-client==0.0.7
+nada-dsl>=0.0.7
+py-nillion-client>=0.0.7


### PR DESCRIPTION
This PR fixes two bugs related to versions. When running `create_venv.sh`, it tries to use python3.11 which was not working.

Also, when it tried to install `nada_dsl` and `py-nillion-client` it was querying for an older version `0.0.7` which can no longer be downloaded. Changed it so that it works with versions `>= 0.0.7`.