### PR TITLE
fix: update pip version in create_venv.sh file

### DIFF
--- a/create_venv.sh
+++ b/create_venv.sh
@@ -7,7 +7,7 @@ function create_venv () {
   fi
 
   echo "Creating virtualenv"
-  pip install --user virtualenv==20.24.6
+  python3 -m pip install --user virtualenv==20.24.6
 
   NILLION_VENV=".venv"
   mkdir -p "$NILLION_VENV"
@@ -16,7 +16,7 @@ function create_venv () {
   python3 -m pip install -r requirements.txt
 
   echo "Virtualenv: $NILLION_VENV"
-  echo "Check the $NILLION_VENV/lib/python3/site-packages folder to make sure you have py_nillion_client and nada_dsl packages"
+  echo "Check the $NILLION_VENV/lib/python3.1X/site-packages folder to make sure you have py_nillion_client and nada_dsl packages"
   echo "📋 Copy and run the following command to activate your environment:"
   echo "source $NILLION_VENV/bin/activate"
 }


### PR DESCRIPTION
This PR sits on top of #8.

`pip install` may use the default python2 version instead of python3. This PR makes sure we always use `python3 -m pip`.