### PR TITLE
fix: typo in correlation coefficient that broke the program execution

### DIFF
--- a/examples_and_tutorials/core_concept_single_party_compute/correlation_coefficient.py
+++ b/examples_and_tutorials/core_concept_single_party_compute/correlation_coefficient.py
@@ -21,8 +21,8 @@ async def main():
     userkey = getUserKeyFromFile(os.getenv("NILLION_USERKEY_PATH_PARTY_1"))
     nodekey = getNodeKeyFromFile(os.getenv("NILLION_NODEKEY_PATH_PARTY_1"))
     client = create_nillion_client(userkey, nodekey)
-    party_id = client.party_id()
-    user_id = client.user_id()
+    party_id = client.party_id
+    user_id = client.user_id
     party_0_name="Party0"
     party_1_name="Party1"
     out_party_name="OutParty"


### PR DESCRIPTION
Small fix that broke the execution of the correlation coefficient program.