### PR TITLE
Fix for Millionaire demo project

### DIFF
--- a/examples_and_tutorials/millionaires_problem_example/01_store_secret_party1.py
+++ b/examples_and_tutorials/millionaires_problem_example/01_store_secret_party1.py
@@ -5,6 +5,7 @@ import pytest
 
 from dotenv import load_dotenv
 from config import (
+    CONFIG_PROGRAM_NAME,
     CONFIG_PARTY_1
 )
 

--- a/examples_and_tutorials/millionaires_problem_example/01_store_secret_party1.py
+++ b/examples_and_tutorials/millionaires_problem_example/01_store_secret_party1.py
@@ -24,7 +24,7 @@ async def main():
     millionaires_program_name = "millionaires"
     
     # Note: check out the code for the full millionaires program in the programs folder
-    program_mir_path = "millionaires.nada.bin"
+    program_mir_path=f"../../programs-compiled/{CONFIG_PROGRAM_NAME}.nada.bin"
 
     # Store millionaires program in the network
     print(f"Storing program in the network: {millionaires_program_name}")

--- a/examples_and_tutorials/millionaires_problem_example/config.py
+++ b/examples_and_tutorials/millionaires_problem_example/config.py
@@ -2,6 +2,7 @@ import os
 import py_nillion_client as nillion
 from dotenv import load_dotenv
 load_dotenv()
+CONFIG_PROGRAM_NAME="millionaires"
 
 # Alice
 CONFIG_PARTY_1={

--- a/examples_and_tutorials/millionaires_problem_example/config.py
+++ b/examples_and_tutorials/millionaires_problem_example/config.py
@@ -30,4 +30,3 @@ CONFIG_N_PARTIES=[
         "secret_name": "charlie_salary",
         "secret_value": 12000,
     },
-]


### PR DESCRIPTION
Hi! I found this pathing bug while doing the Millionaire demo project in the Nillion docs. I did this fix for it and Steph encouraged me to raise an issue and do a PR for it.

Here is the issue I raised:
https://github.com/NillionNetwork/nillion-python-starter/issues/28

This is my commit to fix it, it updates the config file to hold the "CONFIG_PROGRAM_NAME="millionaires"" variable. It also sets the path variable inside 01_store_secret_party1.py to use the compiled .nada.bin file in the programs-compile directory.

I saw this method being used in the nillion-python-starter/examples_and_tutorials/core_concept_multi_party_compute project.