### PR TITLE
Fix spelling and capitalization errors in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-# Nillion Python Starter <a href="https://github.com/NillionNetwork/nillion-python-starter/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg"></a>
+# Nillion Python Starter <a href="https://github.com/NillionNetwork/nillion-Python-starter/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg"></a>
 
 Welcome to the start of your Nillion developer journey.
 
-This repo corresponds to the Nillion Python quickstart. To get started with Nillion head over to the [Python QuickStart docs](https://docs.nillion.com/python-quickstart) and follow the quickstart guide. 
+This repo corresponds to the Nillion Python quickstart. To get started with Nillion head over to the [Python QuickStart docs](https://docs.nillion.com/Python-quickstart) and follow the quickstart guide. 
 
-For more python examples, check out https://github.com/NillionNetwork/python-examples which contains the following:
+For more Python examples, check out https://github.com/NillionNetwork/Python-examples which contains the following:
 - core_concept_multi_party_compute
 - core_concept_permissions
 - core_concept_single_party_compute
 - core_concept_store_and_retrieve_secrets
-- millionaires_problem_example
+- millionaire's_problem_example
 - nada_programs
 - voting_tutorial


### PR DESCRIPTION
- Corrected "python" to "Python"
- Fixed "millionaires_problem_example" to "millionaire's_problem_example"